### PR TITLE
chore: pin dependencies to immutable SHAs via ghat

### DIFF
--- a/examples/lesson3/module.ip.tf
+++ b/examples/lesson3/module.ip.tf
@@ -1,4 +1,3 @@
 module "ip" {
-  source  = "JamesWoolfenden/ip/http"
-  version = "0.2.8"
+  source = "git::https://github.com/JamesWoolfenden/terraform-http-ip.git?ref=2f3cef24e667fb840a3d3481f5a1aaa5a1ac7d28" #v0.3.14
 }


### PR DESCRIPTION
Automated dependency pinning by [ghat](https://github.com/JamesWoolfenden/ghat).

Pins GitHub Actions, pre-commit hooks, Terraform modules/providers, Dockerfiles, and Kubernetes images to SHA digests.